### PR TITLE
Improvement/mtime full precision

### DIFF
--- a/bin/mtime_cache
+++ b/bin/mtime_cache
@@ -147,7 +147,7 @@ globs.each do |glob|
     next if !File.file?(file)
 
     mtime = File.mtime(file)
-    mtime_str = mtime.iso8601(10)
+    mtime_str = mtime.iso8601(9) # nanoseconds precision
     hash = Digest::MD5.hexdigest(File.read(file))
 
     cached = cache[file]

--- a/bin/mtime_cache
+++ b/bin/mtime_cache
@@ -146,24 +146,29 @@ globs.each do |glob|
   Dir[glob].each do |file|
     next if !File.file?(file)
 
-    mtime = File.mtime(file).iso8601(10)
+    mtime = File.mtime(file)
+    mtime_str = mtime.iso8601(10)
     hash = Digest::MD5.hexdigest(File.read(file))
 
     cached = cache[file]
 
-    cached_mtime = Time.parse(cached['mtime'])
-    if cached && cached['hash'] == hash && cached_mtime < mtime
-      mtime = cached_mtime
+    if cached && cached['hash'] == hash
+      cached_mtime_str = cached['mtime']
+      cached_mtime = Time.parse(cached_mtime_str)
+      if cached_mtime < mtime
+        mtime = cached_mtime
+        mtime_str = cached_mtime_str
 
-      log "mtime_cache: changing mtime of #{file} to #{mtime}", 1
+        log "mtime_cache: changing mtime of #{file} to #{mtime_str}", 1
 
-      File.utime(File.atime(file), Time.at(mtime), file) if !ARGS[:dry]
-      num_changed += 1
+        File.utime(File.atime(file), mtime, file) if !ARGS[:dry]
+        num_changed += 1
+      end
     else
       log "mtime_cache: NOT changing mtime of #{file}", 1
     end
 
-    files[file] = { 'mtime' => mtime, 'hash' => hash }
+    files[file] = { 'mtime' => mtime_str, 'hash' => hash }
   end
 end
 

--- a/bin/mtime_cache
+++ b/bin/mtime_cache
@@ -26,6 +26,7 @@
 require 'digest/md5'
 require 'json'
 require 'fileutils'
+require 'time'
 
 VERSION = "1.0.2"
 
@@ -145,13 +146,14 @@ globs.each do |glob|
   Dir[glob].each do |file|
     next if !File.file?(file)
 
-    mtime = File.mtime(file).to_i
+    mtime = File.mtime(file).iso8601(10)
     hash = Digest::MD5.hexdigest(File.read(file))
 
     cached = cache[file]
 
-    if cached && cached['hash'] == hash && cached['mtime'] < mtime
-      mtime = cached['mtime']
+    cached_mtime = Time.parse(cached['mtime'])
+    if cached && cached['hash'] == hash && cached_mtime < mtime
+      mtime = cached_mtime
 
       log "mtime_cache: changing mtime of #{file} to #{mtime}", 1
 

--- a/bin/mtime_cache
+++ b/bin/mtime_cache
@@ -142,24 +142,31 @@ end
 files = {}
 num_changed = 0
 
+def str_from_time(time)
+  time.iso8601(9) # nanoseconds precision
+  # time.to_i
+end
+
 globs.each do |glob|
   Dir[glob].each do |file|
     next if !File.file?(file)
 
     mtime = File.mtime(file)
-    mtime_str = mtime.iso8601(9) # nanoseconds precision
     hash = Digest::MD5.hexdigest(File.read(file))
 
     cached = cache[file]
 
     if cached && cached['hash'] == hash
-      cached_mtime_str = cached['mtime']
-      cached_mtime = Time.parse(cached_mtime_str)
+      cached_mtime_value = cached['mtime']
+      cached_mtime = if cached_mtime_value.is_a?(Integer)
+                       Time.at(cached_mtime_value)
+                     else
+                       Time.parse(cached_mtime_value)
+                     end
       if cached_mtime < mtime
         mtime = cached_mtime
-        mtime_str = cached_mtime_str
 
-        log "mtime_cache: changing mtime of #{file} to #{mtime_str}", 1
+        log "mtime_cache: changing mtime of #{file} to #{str_from_time(mtime)}", 1
 
         File.utime(File.atime(file), mtime, file) if !ARGS[:dry]
         num_changed += 1
@@ -168,7 +175,7 @@ globs.each do |glob|
       log "mtime_cache: NOT changing mtime of #{file}", 1
     end
 
-    files[file] = { 'mtime' => mtime_str, 'hash' => hash }
+    files[file] = { 'mtime' => str_from_time(mtime), 'hash' => hash }
   end
 end
 


### PR DESCRIPTION
This adds ability to restore mtime values in full nanoseconds precision.

This is required to have reliable incremental builds because some builds systems such as llbuild (https://github.com/apple/swift-llbuild) checks mtime in full precision, rather than checking only seconds.